### PR TITLE
Fix sendSms() never resolves on Android 14+ (PendingIntent Issue) 

### DIFF
--- a/android/src/main/java/expo/modules/androidsmssender/ExpoAndroidSmsSenderModule.kt
+++ b/android/src/main/java/expo/modules/androidsmssender/ExpoAndroidSmsSenderModule.kt
@@ -80,7 +80,7 @@ class ExpoAndroidSmsSenderModule : Module() {
   }
 
   private fun createSentPendingIntent(context: Context, promise: Promise): PendingIntent {
-    val intent = Intent(SMS_SENT_ACTION)
+    val intent = Intent(SMS_SENT_ACTION).setPackage(context.packageName)
     val pendingIntent = PendingIntent.getBroadcast(
       context,
       System.currentTimeMillis().toInt(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expo-android-sms-sender",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expo-android-sms-sender",
-      "version": "0.1.0",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-android-sms-sender",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Expo module for sending SMS messages on Android using native code. Built for React Native projects.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Issue Summary

This PR fixes the issue where the `sendSms()` function never resolves or rejects on Android 14+ due to implicit intent restrictions on `PendingIntent`.

## Root Cause
Android 14 enforces stricter security rules, preventing implicit intents from being used in `PendingIntent.getBroadcast()`. The SMS status broadcast was never received, causing the promise to remain unresolved.

## Fix Implemented

### ✅ Updated PendingIntent to use an explicit intent:

Before (implicit intent, not allowed on Android 14+):
```kotlin
val intent = Intent(SMS_SENT_ACTION)
```

After (explicit intent, works on Android 14+):
```kotlin
val intent = Intent(SMS_SENT_ACTION).setPackage(context.packageName)
```

### How It Works Now
- The BroadcastReceiver properly receives the SMS status update.
- The promise now correctly resolves or rejects based on the SMS send result.

## Changes Made

- Updated the PendingIntent intent to be explicit.
- Ensured BroadcastReceiver is correctly registered with ContextCompat.RECEIVER_NOT_EXPORTED.
- Verified compliance with Android 14 security changes.

## Related Issue

Closes #4 

